### PR TITLE
offset camera and hide controllers if no headset, attempt #2

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,10 +31,12 @@
       </a-entity>
       <a-entity id="left-hand"
                 brush
+                if-no-vr-headset="visible: false"
                 paint-controls="hand: left"
                 ui></a-entity>
       <a-entity id="right-hand"
                 brush
+                if-no-vr-headset="visible: false"
                 paint-controls="hand: right"
                 ui></a-entity>
       <a-entity id="ground"
@@ -42,7 +44,11 @@
                 rotation="-90 0 0"
                 material="shader: flat; src: #floor">
       </a-entity>
-      <a-entity position="0 0 0" id="sky" geometry="primitive:sphere; radius:30; phiLength:360; phiStart:0; thetaLength:90" material="shader:flat; side:back; height:2048; src:#skymap; width:2048"></a-entity>
+      <a-entity id="sky" geometry="primitive:sphere; radius:30; phiLength:360; phiStart:0; thetaLength:90" material="shader:flat; side:back; height:2048; src:#skymap; width:2048"></a-entity>
+
+      <a-entity if-no-vr-headset="position: 0 0 2.5">
+        <a-camera></a-camera>
+      </a-entity>
     </a-scene>
     <div id="apainter-ui">
       <div class="progress hide">

--- a/src/components/if-no-vr-headset.js
+++ b/src/components/if-no-vr-headset.js
@@ -1,0 +1,37 @@
+/* global AFRAME */
+var utils = AFRAME.utils;
+
+/**
+ * Set properties if headset is not connected by checking getVRDisplays().
+ */
+AFRAME.registerComponent('if-no-vr-headset', {
+  schema: {
+    default: {},
+    parse: utils.styleParser.parse
+  },
+
+  update: function () {
+    var self = this;
+
+    // Don't count mobile as VR.
+    if (this.el.sceneEl.isMobile) {
+      this.setProperties();
+      return;
+    }
+
+    // Check VRDisplays to determine if headset is connected.
+    navigator.getVRDisplays().then(function (displays) {
+      // Special case for WebVR emulator.
+      if (displays.length && displays[0].displayName !== 'Emulated HTC Vive DVT') { return; }
+      self.setProperties();
+    });
+  },
+
+  setProperties: function () {
+    var data = this.data;
+    var el = this.el;
+    Object.keys(data).forEach(function set (component) {
+      el.setAttribute(component, data[component]);
+    });
+  }
+});

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ require('./systems/brush.js');
 require('./systems/ui.js');
 
 require('./components/brush.js');
+require('./components/if-no-vr-headset.js');
 require('./components/json-model.js');
 require('./components/line.js');
 require('./components/paint-controls.js');


### PR DESCRIPTION
The previous attempt didn't work because it was checking the headset quaternion, which if you are not in VR mode, will be zero'ed even if you have a headset connected.

This time tested on both laptop + vive

laptop: back 2.5 meters, cannot see controllers
with vive: at 0,0,0, can see/use controllers