### PR TITLE
Fix Save Functionality

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 require('../vendor/aframe.min.js');
-require('../vendor/saveas.js');
+window.saveAs = require('../vendor/saveas.js').saveAs;
 
 require('./binarymanager.js');
 require('./ui2d.js');


### PR DESCRIPTION
It looks like Webpack was preventing saveAs from being bound to the global scope and Aframe is using it outside the bundle in [main.js](https://github.com/aframevr/a-painter/blob/master/src/main.js#L82)

I added saveAs to the global scope explicitly and it seems to have fixed the issue.