### PR TITLE
Fix backface visibility of splash screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       <a-light type="point" light="color: #fff; intensity:0.6" position="3 10 1"></a-light>
       <a-light type="point" light="color: #fff; intensity:0.2" position="-3 -10 0"></a-light>
       <a-light type="hemisphere" groundColor="#888" intensity="0.8"></a-light>
-      <a-entity id="logo" obj-model="obj: #logoobj; mtl: #logomtl">
+      <a-entity id="logo" material="side: double;" obj-model="obj: #logoobj; mtl: #logomtl" obj-model-material-modifier="side: double">
         <a-animation begin="fadeout" attribute="material.opacity" fill="none" from="1" to="0" dur="3000"></a-animation>
       </a-entity>
       <a-entity id="left-hand"

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       <a-light type="point" light="color: #fff; intensity:0.6" position="3 10 1"></a-light>
       <a-light type="point" light="color: #fff; intensity:0.2" position="-3 -10 0"></a-light>
       <a-light type="hemisphere" groundColor="#888" intensity="0.8"></a-light>
-      <a-entity id="logo" material="side: double;" obj-model="obj: #logoobj; mtl: #logomtl" obj-model-material-modifier="side: double">
+      <a-entity id="logo" obj-model="obj: #logoobj; mtl: #logomtl" obj-model-material-modifier="side: double">
         <a-animation begin="fadeout" attribute="material.opacity" fill="none" from="1" to="0" dur="3000"></a-animation>
       </a-entity>
       <a-entity id="left-hand"

--- a/src/components/obj-model-material-modifier.js
+++ b/src/components/obj-model-material-modifier.js
@@ -8,7 +8,6 @@ AFRAME.registerComponent('obj-model-material-modifier', {
   },
 
   init: function () {
-    var that = this;
     var el = this.el;
     var side = this.sideToThreeSide(this.data.side)
     if (!side) {

--- a/src/components/obj-model-material-modifier.js
+++ b/src/components/obj-model-material-modifier.js
@@ -1,0 +1,34 @@
+/* globals AFRAME THREE */
+
+// Allow modifying the materials returned from obj-model loader .mtl files.
+// We can add any ThreeJS.Material specific options that .mtl doesn't support.
+AFRAME.registerComponent('obj-model-material-modifier', {
+  schema: {
+    side: {type: 'string'}
+  },
+
+  init: function () {
+    var that = this;
+    var el = this.el;
+    var side = this.sideToThreeSide(this.data.side)
+    if (!side) {
+      console.warn("No options present on obj-model-material-modifier");
+      return;
+    }
+    this.el.addEventListener('model-loaded', function(e) {
+      el.object3D.traverse(function (o) {
+        if (o instanceof THREE.Mesh) {
+          o.material.side = side
+        }
+      });
+    })
+  },
+  
+  sideToThreeSide: function(side) {
+    return {
+      "double": THREE.DoubleSide,
+      "front": THREE.FrontSide,
+      "back": THREE.BackSide
+    }[side];
+  }
+});

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ require('./components/if-no-vr-headset.js');
 require('./components/json-model.js');
 require('./components/line.js');
 require('./components/look-controls-alt.js');
+require('./components/obj-model-material-modifier.js');
 require('./components/orbit-controls.js');
 require('./components/paint-controls.js');
 require('./components/ui.js');


### PR DESCRIPTION
Fixes #135 
.mtl files don't support backface visibility, so i added a component that would allow us to modify obj-model materials after they load for ThreeJS specific properties.  Currently the component only supports side, but we can add anything else at https://threejs.org/docs/#Reference/Materials/Material that we need later.
