### PR TITLE
Adding a class "a-stroke" to all entities created as strokes

### DIFF
--- a/src/systems/brush.js
+++ b/src/systems/brush.js
@@ -216,6 +216,7 @@ AFRAME.registerSystem('brush', {
     this.strokes.push(stroke);
 
     var entity = document.createElement('a-entity');
+    entity.className = "a-stroke";
     document.querySelector('a-scene').appendChild(entity);
     entity.setObject3D('mesh', stroke.object3D);
     stroke.entity = entity;


### PR DESCRIPTION
Entities can then be modified and reused using e.g. `document.querySelectorAll("[class=a-stroke]");`

This should greatly facilitate :
- https://github.com/aframevr/a-painter/issues/144
- https://github.com/aframevr/a-painter/issues/72
- https://github.com/aframevr/a-painter/issues/73
and overall interaction from classical Aframe components.