### PR TITLE
Add Multiplayer Support

### DIFF
--- a/src/systems/brush.js
+++ b/src/systems/brush.js
@@ -218,7 +218,9 @@ AFRAME.registerSystem('brush', {
       }
     }
   },
-  addNewStroke: function (brushName, color, size, owner='local', timestamp=Date.now()) {
+  addNewStroke: function (brushName, color, size, owner, timestamp) {
+    owner = owner || 'local';
+    timestamp = timestamp || Date.now();
     var Brush = this.getBrushByName(brushName);
     if (!Brush) {
       var newBrushName = Object.keys(AFRAME.BRUSHES)[0];


### PR DESCRIPTION
This implements the concept of ownership to a stroke so that a multiplayer implementation can distinguish between local and remote ones.

Also added time-stamps to strokes so that can be identified and correct event calls on generate random and clear.

With these changes, people can easily implement their own multiplayer quite easily, I have an example here: https://github.com/mrfrase3/a-painter-socket-server