### PR TITLE
enable `devServer.disableHostCheck` in Webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,8 @@
-var webpack = require('webpack');
+const webpack = require('webpack');
 
-var PLUGINS = [];
+let PLUGINS = [];
 if (process.env.NODE_ENV === 'production') {
-  new webpack.optimize.UglifyJsPlugin()
+  PLUGINS.push(new webpack.optimize.UglifyJsPlugin());
 }
 
 module.exports = {
@@ -11,5 +11,8 @@ module.exports = {
     path: __dirname,
     filename: 'build.js'
   },
-  plugins: PLUGINS
+  plugins: PLUGINS,
+  devServer: {
+    disableHostCheck: true
+  }
 };


### PR DESCRIPTION
- match the settings in the `webpack.config.js` files in the [A-Blast](https://github.com/aframevr/a-blast/blob/master/webpack.config.js) and [A Saturday Night](https://github.com/aframevr/a-saturday-night/blob/master/webpack.config.js) projects
- fix `PLUGINS` bug (somehow https://aframe.io/a-painter/build.js is still minified; I'm probably missing something somewhere)

