### PR TITLE
Add support for windows controllers

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,24 @@
                         position="0.058 -0.01 0.055">
                     </a-entity>
                   </a-entity>
+                  <a-entity class="windows-motion-tooltips" visible="false">
+                    <a-entity tooltip="text: Trigger to paint!; width: 0.1; height: 0.04; targetPosition: 0 -.3 -.1; lineHorizontalAlign: center; lineVerticalAlign: bottom; src: assets/images/tooltip.png"
+                              position="0 -.1 -.2"
+                              rotation="-90 0 0">
+                    </a-entity>
+                    <a-entity tooltip="text: Main menu; width: 0.07; height: 0.03; targetPosition: 0.01 0.0025 -.06; lineHorizontalAlign: right; src: assets/images/tooltip.png"
+                              position="-0.1 0.02 -.05"
+                              rotation="-90 0 0">
+                    </a-entity>
+                    <a-entity tooltip="text: Brush size\n(up/down); width: 0.11; height: 0.04; targetPosition: 0 -.09 -.1; lineHorizontalAlign: left; src: assets/images/tooltip.png"
+                              position="0.14 0 -.1"
+                              rotation="-90 0 0">
+                    </a-entity>
+                    <a-entity tooltip="text: Press to undo; width: 0.11; height: 0.03; targetPosition: 0 0 0; lineHorizontalAlign: left; src: assets/images/tooltip.png"
+                              position="0.11 0 0"
+                              rotation="-90 0 0">
+                    </a-entity>
+                </a-entity>
                 </a-entity>
       <a-entity id="right-hand"
                 brush
@@ -127,6 +145,24 @@
                     </a-entity>
                     <a-entity tooltip="text: Undo; width: 0.05; height: 0.03; targetPosition: -0.005 -0.022 0.027; rotation: -90 0 0; lineHorizontalAlign: right; src: assets/images/tooltip.png"
                         position="-0.058 -0.01 0.055">
+                    </a-entity>
+                  </a-entity>
+                  <a-entity class="windows-motion-tooltips" visible="false">
+                    <a-entity tooltip="text: Trigger to paint!; width: 0.1; height: 0.04; targetPosition: 0 -.3 -.1; lineHorizontalAlign: center; lineVerticalAlign: bottom; src: assets/images/tooltip.png"
+                              position="0 -.1 -.2"
+                              rotation="-90 0 0">
+                    </a-entity>
+                    <a-entity tooltip="text: Main menu; width: 0.07; height: 0.03; targetPosition: -.015 0.0025 -.06; lineHorizontalAlign: left; src: assets/images/tooltip.png"
+                              position="0.1 0.02 -.05"
+                              rotation="-90 0 0">
+                    </a-entity>
+                    <a-entity tooltip="text: Brush size\n(up/down); width: 0.11; height: 0.04; targetPosition: 0 -.09 -.1; lineHorizontalAlign: right; src: assets/images/tooltip.png"
+                              position="-0.14 0 -.1"
+                              rotation="-90 0 0">
+                    </a-entity>
+                    <a-entity tooltip="text: Press to undo; width: 0.11; height: 0.03; targetPosition: 0 0 0; lineHorizontalAlign: right; src: assets/images/tooltip.png"
+                              position="-0.11 0 0"
+                              rotation="-90 0 0">
                     </a-entity>
                   </a-entity>
       </a-entity>

--- a/src/components/ui.js
+++ b/src/components/ui.js
@@ -61,6 +61,7 @@ AFRAME.registerComponent('ui', {
     this.controller = null;
 
     var self = this;
+
     el.addEventListener('controllerconnected', function (evt) {
       var controllerName = evt.detail.name;
 
@@ -75,6 +76,11 @@ AFRAME.registerComponent('ui', {
         self.rayAngle = 0;
         el.setAttribute('ui-raycaster', {
           rotation: 0
+        });
+      } else if (controllerName === 'windows-motion-controls') {
+        self.rayAngle = 25;
+        el.setAttribute('ui-raycaster', {
+          rotation: -30
         });
       }
 
@@ -452,7 +458,7 @@ AFRAME.registerComponent('ui', {
       } else {
         el.addEventListener('abuttondown', this.toggleMenu);
       }
-    } else if (this.controller.name === 'vive-controls') {
+    } else if (this.controller.name === 'vive-controls' || this.controller.name === 'windows-motion-controls') {
       el.addEventListener('menudown', this.toggleMenu);
     }
   },
@@ -466,7 +472,7 @@ AFRAME.registerComponent('ui', {
       } else {
         el.removeEventListener('abuttondown', this.toggleMenu);
       }
-    } else if (this.controller.name === 'vive-controls') {
+    } else if (this.controller.name === 'vive-controls' || this.controller.name === 'windows-motion-controls') {
       el.removeEventListener('menudown', this.toggleMenu);
     }
   },

--- a/src/systems/brush.js
+++ b/src/systems/brush.js
@@ -37,9 +37,9 @@ AFRAME.registerBrush = function (name, definition, options) {
       for (var i = 0; i < this.data.points.length; i++) {
         var point = this.data.points[i];
         points.push({
-          'orientation': point.orientation.toArray().toNumFixed(6),
-          'position': point.position.toArray().toNumFixed(6),
-          'pressure': point.pressure.toNumFixed(6),
+          'orientation': Utils.arrayNumbersToFixed(point.orientation.toArray()),
+          'position': Utils.arrayNumbersToFixed(point.position.toArray()),
+          'pressure': Utils.numberToFixed(point.pressure),
           'timestamp': point.timestamp
         });
       }
@@ -47,8 +47,8 @@ AFRAME.registerBrush = function (name, definition, options) {
       return {
         brush: {
           index: system.getUsedBrushes().indexOf(this.brushName),
-          color: this.data.color.toArray().toNumFixed(6),
-          size: this.data.size.toNumFixed(6)
+          color: Utils.arrayNumbersToFixed(this.data.color.toArray()),
+          size: Utils.numberToFixed(this.data.size),
         },
         points: points
       };
@@ -305,6 +305,10 @@ AFRAME.registerSystem('brush', {
       'oculus-touch-controls': {
         vec: new THREE.Vector3(0, 0, 2.8),
         mult: -0.05
+      },
+      'windows-motion-controls': {
+        vec: new THREE.Vector3(0, 0, 1),
+        mult: -.12
       }
     };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,18 @@
-Number.prototype.toNumFixed = function (num) {
-  return parseFloat(this.toFixed(num));
-}
+window.Utils = function() {
+    const DIGITS = 6;
+    function numberToFixed (number) {
+        return parseFloat(number.toFixed(DIGITS));
+    }
 
-Array.prototype.toNumFixed = function (num) {
-  for (var i = 0; i < this.length; i++) {
-    this[i] = this[i].toNumFixed(num);
-  }
-  return this;
+    function arrayNumbersToFixed (array) {
+        for (var i = 0; i < array.length; i++) {
+            array[i] = numberToFixed(array[i]);
+        }
+        return this;
+    }
+
+    return {
+        numberToFixed: numberToFixed,
+        arrayNumbersToFixed: arrayNumbersToFixed
+    }
 }


### PR DESCRIPTION
Add support for windows motion controllers to a-painter.
Future improvements should include the use of the existing laser controls component in order to make use of the rayOrigin values.
Current limitations for windows-motion-controllers: brush size hint does not appear.
Support also needs to be added to aframe-teleport-controls for windows-motion-controllers as we would prefer to use the thumbstick for teleporting.