### PR TITLE
Performance: sharedbuffergeometry update ranges

### DIFF
--- a/src/sharedbuffergeometry.js
+++ b/src/sharedbuffergeometry.js
@@ -80,9 +80,13 @@ SharedBufferGeometry.prototype = {
 
     geometry.setDrawRange(0, 0);
     geometry.addAttribute('position', new THREE.BufferAttribute(vertices, 3).setDynamic(true));
+    geometry.attributes.position.updateRange.count = 0;
     geometry.addAttribute('uv', new THREE.BufferAttribute(uvs, 2).setDynamic(true));
+    geometry.attributes.uv.updateRange.count = 0;
     geometry.addAttribute('normal', new THREE.BufferAttribute(normals, 3).setDynamic(true));
+    geometry.attributes.normal.updateRange.count = 0;
     geometry.addAttribute('color', new THREE.BufferAttribute(colors, 3).setDynamic(true));
+    geometry.attributes.color.updateRange.count = 0;
 
 
     this.previous = null;
@@ -147,9 +151,13 @@ SharedBufferGeometry.prototype = {
   update: function () {
     this.current.setDrawRange(0, this.idx.position);
 
+    this.current.attributes.color.updateRange.count = this.idx.position * 3;
     this.current.attributes.color.needsUpdate = true;
+    this.current.attributes.normal.updateRange.count = this.idx.position * 3;
     this.current.attributes.normal.needsUpdate = true;
+    this.current.attributes.position.updateRange.count = this.idx.position * 3;
     this.current.attributes.position.needsUpdate = true;
+    this.current.attributes.uv.updateRange.count = this.idx.position * 2;
     this.current.attributes.uv.needsUpdate = true;
   }
 };


### PR DESCRIPTION
The brush geometries seem to be [1 MB](https://github.com/aframevr/a-painter/compare/master...modulesio:master#diff-62f2cf4b4f8c70b7792c06d42ecdb3c7L5), re-uploaded on every tick. That's pretty taxing for 90FPS.

This sets the `updateRange` for brush geometries, so in most cases only a little bit of the geometry is uploaded by THREE.js (exactly as much as we have drawn).

Without this I was unable to hit 90FPS when drawing, even with straight OpenGL. But with, it it seems very smooth.