### PR TITLE
Fix a-painter issue #250 where tooltip labels appear off on Samsung controllers

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,24 @@
                           position="0.058 -0.01 0.055">
                       </a-entity>
                     </a-entity>
+                    <a-entity class="windows-motion-samsung-tooltips" visible="false">
+                      <a-entity tooltip="text: Trigger to paint!; width: 0.1; height: 0.04; targetPosition: 0 -.3 -.1; lineHorizontalAlign: center; lineVerticalAlign: bottom; src: assets/images/tooltip.png"
+                                position="0 -.1 -.2"
+                                rotation="-90 0 0">
+                      </a-entity>
+                      <a-entity tooltip="text: Main menu; width: 0.07; height: 0.03; targetPosition: 0.005 -0.002 -.06; lineHorizontalAlign: right; src: assets/images/tooltip.png"
+                                position="-0.1 0.02 -.05"
+                                rotation="-90 0 0">
+                      </a-entity>
+                      <a-entity tooltip="text: Brush size\n(up/down); width: 0.11; height: 0.04; targetPosition: 0 -.09 -.1; lineHorizontalAlign: left; src: assets/images/tooltip.png"
+                                position="0.2 0 -.11"
+                                rotation="-90 0 0">
+                      </a-entity>
+                      <a-entity tooltip="text: Press to undo; width: 0.11; height: 0.03; targetPosition: 0 0 0; lineHorizontalAlign: left; src: assets/images/tooltip.png"
+                                position="0.11 0 0"
+                                rotation="-90 0 0">
+                      </a-entity>
+                    </a-entity>
                     <a-entity class="windows-motion-tooltips" visible="false">
                       <a-entity tooltip="text: Trigger to paint!; width: 0.1; height: 0.04; targetPosition: 0 -.3 -.1; lineHorizontalAlign: center; lineVerticalAlign: bottom; src: assets/images/tooltip.png"
                                 position="0 -.1 -.2"
@@ -155,6 +173,24 @@
                       </a-entity>
                       <a-entity tooltip="text: Undo; width: 0.05; height: 0.03; targetPosition: -0.005 -0.022 0.027; rotation: -90 0 0; lineHorizontalAlign: right; src: assets/images/tooltip.png"
                           position="-0.058 -0.01 0.055">
+                      </a-entity>
+                    </a-entity>
+                    <a-entity class="windows-motion-samsung-tooltips" visible="false">
+                      <a-entity tooltip="text: Trigger to paint!; width: 0.1; height: 0.04; targetPosition: 0 -.3 -.1; lineHorizontalAlign: center; lineVerticalAlign: bottom; src: assets/images/tooltip.png"
+                                position="0 -.1 -.2"
+                                rotation="-90 0 0">
+                      </a-entity>
+                      <a-entity tooltip="text: Main menu; width: 0.07; height: 0.03; targetPosition: -.01 -0.004 -.06; lineHorizontalAlign: left; src: assets/images/tooltip.png"
+                                position="0.1 0.02 -.05"
+                                rotation="-90 0 0">
+                      </a-entity>
+                      <a-entity tooltip="text: Brush size\n(up/down); width: 0.11; height: 0.04; targetPosition: 0 -.09 -.1; lineHorizontalAlign: right; src: assets/images/tooltip.png"
+                                position="-0.19 -0.003 -.11"
+                                rotation="-90 0 0">
+                      </a-entity>
+                      <a-entity tooltip="text: Press to undo; width: 0.11; height: 0.03; targetPosition: 0 0 0; lineHorizontalAlign: right; src: assets/images/tooltip.png"
+                                position="-0.11 0 0"
+                                rotation="-90 0 0">
                       </a-entity>
                     </a-entity>
                     <a-entity class="windows-motion-tooltips" visible="false">

--- a/src/components/paint-controls.js
+++ b/src/components/paint-controls.js
@@ -59,8 +59,21 @@ AFRAME.registerComponent('paint-controls', {
 
     el.addEventListener('controllerconnected', function (evt) {
       var controllerName = evt.detail.name;
+      if (controllerName === 'windows-motion-controls')
+      {
+        var gltfName = evt.detail.component.el.components['gltf-model'].data;
+        const SAMSUNG_DEVICE = '045E-065D';
+        if (!!gltfName)
+        {
+          if (gltfName.indexOf(SAMSUNG_DEVICE) >= 0)
+          {
+            controllerName = "windows-motion-samsung-controls";
+          }
+        }
+      }
+
       tooltips = Utils.getTooltips(controllerName);
-      if (controllerName === 'windows-motion-controls') {
+      if (controllerName.indexOf('windows-motion') >= 0) {
         // el.setAttribute('teleport-controls', {button: 'trackpad'});
       } else if (controllerName === 'oculus-touch-controls') {
         var hand = evt.detail.component.data.hand;

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,6 +15,10 @@ window.Utils = (function() {
         var tooltips;
         var tooltipName;
         switch (controllerName) {
+            case 'windows-motion-samsung-controls': {
+                tooltipName = '.windows-motion-samsung-tooltips';
+                break;
+            }
             case 'windows-motion-controls': {
                 tooltipName = '.windows-motion-tooltips';
                 break;


### PR DESCRIPTION
A quick update to the controller tooltips to account for Samsung Windows motion controllers, as the current labels are accurate only for the Acer.