### PR TITLE
Fix brush resizing, check touchpad and thumbstick

### DIFF
--- a/src/components/brush.js
+++ b/src/components/brush.js
@@ -28,19 +28,6 @@ AFRAME.registerComponent('brush', {
 
     var self = this;
 
-    this.previousAxis = 0;
-/*
-    this.el.addEventListener('axismove', function (evt) {
-      if (evt.detail.axis[0] === 0 && evt.detail.axis[1] === 0 || this.previousAxis === evt.detail.axis[1]) {
-        return;
-      }
-
-      this.previousAxis = evt.detail.axis[1];
-      var size = (evt.detail.axis[1] + 1) / 2 * self.schema.size.max;
-
-      self.el.setAttribute('brush', 'size', size);
-    });
-*/
     this.el.addEventListener('undo', function(evt) {
       if (!self.data.enabled) { return; }
       self.system.undo();

--- a/src/components/paint-controls.js
+++ b/src/components/paint-controls.js
@@ -22,9 +22,10 @@ AFRAME.registerComponent('paint-controls', {
     el.addEventListener('model-loaded', this.onModelLoaded);
 
     el.addEventListener('changeBrushSizeAbs', function (evt) {
-      if (evt.detail.axis[0] === 0 && evt.detail.axis[1] === 0 || self.previousAxis === evt.detail.axis[1]) { return; }
+      if (evt.detail.axis[1] === 0 && evt.detail.axis[3] === 0) { return; }
 
-      var delta = evt.detail.axis[1] / 300;
+      var magnitude = evt.detail.axis[1] || evt.detail.axis[3];
+      var delta = magnitude / 300;
       var size = el.components.brush.schema.size;
       var value = THREE.Math.clamp(self.el.getAttribute('brush').size - delta, size.min, size.max);
 
@@ -32,14 +33,16 @@ AFRAME.registerComponent('paint-controls', {
     });
 
     el.addEventListener('changeBrushSizeInc', function (evt) {
-      if (evt.detail.axis[0] === 0 && evt.detail.axis[1] === 0 || self.previousAxis === evt.detail.axis[1]) { return; }
+      if (evt.detail.axis[1] === 0 && evt.detail.axis[3] === 0) { return; }
+
+      var magnitude = evt.detail.axis[1] || evt.detail.axis[3];
 
       if (self.touchStarted) {
         self.touchStarted = false;
-        self.startAxis = (evt.detail.axis[1] + 1) / 2;
+        self.startAxis = (magnitude + 1) / 2;
       }
 
-      var currentAxis = (evt.detail.axis[1] + 1) / 2;
+      var currentAxis = (magnitude + 1) / 2;
       var delta = (self.startAxis - currentAxis) / 2;
 
       self.startAxis = currentAxis;

--- a/src/systems/painter.js
+++ b/src/systems/painter.js
@@ -15,7 +15,7 @@ AFRAME.registerSystem('painter', {
           },
 
           'vive-controls': {
-            'axis.move': 'changeBrushSizeInc',
+            'axismove': 'changeBrushSizeInc',
             'trackpad.touchstart': 'startChangeBrushSize',
             'menu.down': 'toggleMenu',
 
@@ -25,7 +25,7 @@ AFRAME.registerSystem('painter', {
           },
 
           'oculus-touch-controls': {
-            'axis.move': 'changeBrushSizeAbs',
+            'axismove': 'changeBrushSizeAbs',
             'abutton.down': 'toggleMenu',
             'xbutton.down': 'toggleMenu',
 
@@ -38,7 +38,7 @@ AFRAME.registerSystem('painter', {
           },
 
           'windows-motion-controls': {
-            'axis.move': 'changeBrushSizeAbs',
+            'axismove': 'changeBrushSizeAbs',
             'menu.down': 'toggleMenu',
 
             // Teleport


### PR DESCRIPTION
Updated the event names to axismove and added a check for thumbsticks.
Removed some seemingly dead code relating to previousAxis also.